### PR TITLE
Group packets together & Changed header description

### DIFF
--- a/doc/IR Protocol/01 - Packet Format.md
+++ b/doc/IR Protocol/01 - Packet Format.md
@@ -10,13 +10,14 @@ Some packets might not even contain a payload (for instance, an acknowledgment p
 | 8 byte | ??? byte |
 
 ## Header description
-- Bytes 0 and 1 of the header is the Packet ID. It never changes between two sessions, and can be used to identify a packet and deduce its size for instance.  
-- Bytes 2 and 3 of the header is a Checksum, whose algorithm will be described below.  
-- Bytes 4 to 7 of the header is a Session ID. This will change between two sessions, but **never** changes in one session. It is calculated by XORing two values, which will be described in the next chapter.
+- Byte 0 of the header is the Packet ID. It never changes between two sessions, and can be used to identify a packet and deduce its size for instance.  
+- Byte 1 of the header is used by some packet as an argument/flags byte (usually, this byte is set to ``0x01`` for packets sent by Pokemon HGSS, and to ``0x02`` for packets sent by the PokeWalker).
+- Byte 2 and 3 of the header is a Checksum, whose algorithm will be described below.  
+- Byte 4 to 7 of the header is a Session ID. This will change between two sessions, but **never** changes in one session. It is calculated by XORing two values, which will be described in the next chapter.
 
-| Packet ID | Checksum | Session ID |
-|-----------|----------|------------|
-| 2 byte    | 2 byte   | 4 byte     |
+| Packet ID | Packet argument | Checksum | Session ID |
+|-----------|-----------------|----------|------------|
+| 1 byte    | 1 byte          | 2 byte   | 4 byte     |
 
 ## Computing the checksum
 The checksum is calculated using the whole packet, with the Checksum field in the header being zero'ed out.

--- a/doc/IR Protocol/02 - Starting a Communication.md
+++ b/doc/IR Protocol/02 - Starting a Communication.md
@@ -20,13 +20,7 @@ Pokemon will only accept packets when it finished printing the "In a place where
 Pokemon HGSS sends the Session ID it generated (randomly?) to the PokeWalker.  
 Its value doesn't matter, so you can use whatever values you want if you're simulating the Pokemon side (using ``00 00 00 00`` might be a good idea for instance).
 
-This packet doesn't have any payload, and as such is 8 byte long.  
-Its Packet ID is ``0xFA01``.
-
-### Example
-| Packet ID     | Checksum     | Session ID     |
-|---------------|--------------|----------------|
-| ``0xFA01``    | ``0x9008``   | ``0x3F57CF34`` |
+Learn more about this packet [here](Packets/0xFA%20-%20Pokemon%20Session%20ID.md)
 
 ## PokeWalker side: Session ID #2
 The PokeWalker sends the Session ID it generated (randomly too?) to Pokemon HGSS.  
@@ -35,73 +29,23 @@ After this packet, if you're communicating with the PokeWalker, you can skip the
 
 When this packet is sent, the final Session ID is calculated by both sides, by simply XORing Session ID #1 with Session ID #2.
 
-This packet doesn't have any payload, and as such is 8 byte long.  
-Its Packet ID is ``0xF802``.
-
-### Example
-| Packet ID     | Checksum     | Session ID     |
-|---------------|--------------|----------------|
-| ``0xF802``    | ``0x2D70``   | ``0x4A212E07`` |
-
-The resulting Session ID will be ``0x7576E133``.
+Learn more about this packet [here](Packets/0xF8%20-%20PokeWalker%20Session%20ID.md).
 
 ## Pokemon side: Asking for general data
 Pokemon HGSS asks the PokeWalker for its general data, so it can ensure the PokeWalker its communicating with is the one associated with this savefile (if a PokeWalker is registered), or is not already registered (if a PokeWalker is not registered).
 
 This packet doesn't have any payload, and as such is 8 byte long.  
-Its Packet ID is ``0x2001``.
+Its Packet ID is ``0x20`` (Page available [here](Packets/0x20%20-%20Asking%20for%20General%20Data.md)).
 
 ## PokeWalker side: Sending general data
 This is the first packet with a real payload, and it contains some interesting data.  
 At this point, if Pokemon deems that the PokeWalker is invalid, it will terminate the communication, telling the Player that this PokeWalker is not the registered one/is already registered (_needs more documentation_).
 
-The payload has a size of 104 byte, making the packet 112 byte long.  
-Its Packet ID is ``0x2202``.
-
-### Description
-| Offset | Length | Description                                     |
-|--------|--------|-------------------------------------------------|
-| 0x00   | 8      | Header                                          |
-| 0x08   | 12     | _Needs documentation (Trainer data?)_           |
-| 0x14   | 2      | Trainer ID                                      |
-| 0x16   | 2      | Secret ID                                       |
-| 0x18   | 56     | _Needs documentation (Unique data to each PW?)_ |
-| 0x50   | 16     | Trainer Name (Terminated by 0xFFFF)             |
-| 0x60   | 3      | Unknown (Always 0x00)                           |
-| 0x63   | 1      | PokeWalker Status (See below)                   |
-| 0x64   | 4      | _Unknown (Always 0x02?)_                        |
-| 0x68   | 4      | Unknown (Always 0x00)                           |
-| 0x6C   | 4      | Today Step Count                                |
-Values in italic needs more research.
-
-#### PokeWalker Status
-| Bit | Description            |
-|-----|------------------------|
-| 0   | Is Registered          |
-| 1   | Has Pokemon            |
-| 2-7 | Unknown (Always 0x00?) |
+Learn more about this packet [here](Packets/0x22%20-%20General%20Data.md).
 
 ## Pokemon side: Sending general data
 Pokemon sends its general data too, whose format looks to be the same as the one used in the PokeWalker general data packet.
 
-The most notable feature of this packet is located at offset ``0x68``, and is used by the PokeWalker to set its RTC.  
-It seems that if this field is zeroed out, the PokeWalker will not set the clock.
-
-The payload has a size of 104 byte, making the packet 112 byte long.  
-Its Packet ID is ``0x4001``.
-
-### Description
-| Offset | Length | Description                           |
-|--------|--------|---------------------------------------|
-| 0x00   | 8      | Header                                |
-| 0x08   | 12     | _Needs documentation (Trainer data?)_ |
-| 0x14   | 2      | Trainer ID                            |
-| 0x16   | 2      | Secret ID                             |
-| 0x18   | 56     | Unknown (Always 0x00)                 |
-| 0x50   | 16     | Trainer Name (Terminated by 0xFFFF)   |
-| 0x60   | 8      | Unknown (Always 0x00)                 |
-| 0x68   | 4      | Number of seconds since 01/01/2001    |
-| 0x6C   | 4      | Unknown (Always 0x00)                 |
-Values in italic needs more research.
+Learn more about this packet [here](Packets/0x40%20-%20General%20Data.md).
 
 🠖 To be continued...

--- a/doc/IR Protocol/Packets/0x20 - Asking for General Data.md
+++ b/doc/IR Protocol/Packets/0x20 - Asking for General Data.md
@@ -1,0 +1,13 @@
+# Packet 0x20 - Asking for General Data
+## Overview
+- **Packet ID**: ``0x20``
+- **Length**: 8 byte (no payload)
+- **Sent by**: Pokemon HGSS
+- **Used in**: Every communication
+
+After having sent this packet, the PokeWalker will reply with [Packet 0x22 - General Data](0x22%20-%20General%20Data.md).
+
+## Description
+| Offset | Length | Description |
+|--------|--------|-------------|
+| 0x00   | 8      | Header      |

--- a/doc/IR Protocol/Packets/0x22 - General Data.md
+++ b/doc/IR Protocol/Packets/0x22 - General Data.md
@@ -1,0 +1,34 @@
+# Packet 0x22 - General Data
+## Overview
+- **Packet ID**: ``0x22``
+- **Length**: 104 byte (112 with header)
+- **Sent by**: PokeWalker
+- **Used in**: Every communication
+
+This packet looks a lot like [Packet 0x40 - General Data](0x40%20-%20General%20Data.md) sent by Pokemon HGSS.
+
+It is part of every communication, and helps verify the PokeWalker against the current Pokemon HGSS player infos.
+
+## Description
+| Offset | Length | Description                                     |
+|--------|--------|-------------------------------------------------|
+| 0x00   | 8      | Header                                          |
+| 0x08   | 12     | _Needs documentation (Trainer data?)_           |
+| 0x14   | 2      | Trainer ID                                      |
+| 0x16   | 2      | Secret ID                                       |
+| 0x18   | 56     | _Needs documentation (Unique data to each PW?)_ |
+| 0x50   | 16     | Trainer Name (Terminated by 0xFFFF)             |
+| 0x60   | 3      | Unknown (Always 0x00)                           |
+| 0x63   | 1      | PokeWalker Status (See below)                   |
+| 0x64   | 4      | _Unknown (Always 0x02?)_                        |
+| 0x68   | 4      | Unknown (Always 0x00)                           |
+| 0x6C   | 4      | Total Step Count                                |
+
+Values in italic needs more research.
+
+### PokeWalker Status
+| Bit | Description            |
+|-----|------------------------|
+| 0   | Is Registered          |
+| 1   | Has Pokemon            |
+| 2-7 | Unknown (Always 0x00?) |

--- a/doc/IR Protocol/Packets/0x40 - General Data.md
+++ b/doc/IR Protocol/Packets/0x40 - General Data.md
@@ -1,0 +1,26 @@
+# Packet 0x40 - General Data
+## Overview
+- **Packet ID**: ``0x40``
+- **Length**: 104 byte (112 with header)
+- **Sent by**: Pokemon HGSS
+- **Used in**: Every communication
+
+This packet looks a lot like [Packet 0x22 - General Data](0x22%20-%20General%20Data.md) sent by the PokeWalker.
+
+The most notable feature of this packet is located at offset ``0x68``, and is used by the PokeWalker to set its RTC.  
+It seems that if this field is zeroed out, the PokeWalker will not set the clock.
+
+## Description
+| Offset | Length | Description                           |
+|--------|--------|---------------------------------------|
+| 0x00   | 8      | Header                                |
+| 0x08   | 12     | _Needs documentation (Trainer data?)_ |
+| 0x14   | 2      | Trainer ID                            |
+| 0x16   | 2      | Secret ID                             |
+| 0x18   | 56     | Unknown (Always 0x00)                 |
+| 0x50   | 16     | Trainer Name (Terminated by 0xFFFF)   |
+| 0x60   | 8      | Unknown (Always 0x00)                 |
+| 0x68   | 4      | Number of seconds since 01/01/2001    |
+| 0x6C   | 4      | Unknown (Always 0x00)                 |
+
+Values in italic needs more research.

--- a/doc/IR Protocol/Packets/0xF8 - PokeWalker Session ID.md
+++ b/doc/IR Protocol/Packets/0xF8 - PokeWalker Session ID.md
@@ -1,0 +1,21 @@
+# Packet 0xF8 - PokeWalker Session ID
+## Overview
+- **Packet ID**: ``0xF8``
+- **Length**: 8 byte (no payload)
+- **Sent by**: PokeWalker
+- **Used in**: Every communication
+
+This packet is sent as the second part of the Session ID, normally always sent after [Packet 0xFA - Pokemon Session ID](0xFA%20-%20Pokemon%20Session%20ID.md).  
+Once both devices will have received both part of the Session ID, the final Session ID will be calculated by XORing the first part of the Session ID with the second part of the Session ID.
+
+## Description
+| Offset | Length | Description |
+|--------|--------|-------------|
+| 0x00   | 8      | Header      |
+
+## Example Header
+| Packet ID     | Packet argument | Checksum     | Session ID Second part     |
+|---------------|-----------------|--------------|----------------------------|
+| ``0xF8``      | ``0x02``        | ``0x2D70``   | ``0x4A212E07``             |
+
+If the first part of the Session ID was ``0x3F57CF34``, then the resulting final Session ID will be ``0x7576E133``.

--- a/doc/IR Protocol/Packets/0xFA - Pokemon Session ID.md
+++ b/doc/IR Protocol/Packets/0xFA - Pokemon Session ID.md
@@ -1,0 +1,21 @@
+# Packet 0xFA - Pokemon Session ID
+## Overview
+- **Packet ID**: ``0xFA``
+- **Length**: 8 byte (no payload)
+- **Sent by**: Pokemon HGSS
+- **Used in**: Every communication
+
+This packet is sent as the first part of the Session ID, normally always followed by PokeWalker's [Packet 0xF8 - PokeWalker Session ID](0xF8%20-%20PokeWalker%20Session%20ID.md).  
+Once both devices will have received both part of the Session ID, the final Session ID will be calculated by XORing the first part of the Session ID with the second part of the Session ID.
+
+## Description
+| Offset | Length | Description |
+|--------|--------|-------------|
+| 0x00   | 8      | Header      |
+
+## Example Header
+| Packet ID     | Packet argument | Checksum     | Session ID First part     |
+|---------------|-----------------|--------------|---------------------------|
+| ``0xFA``      | ``0x01``        | ``0x9008``   | ``0x3F57CF34``            |
+
+If the second part of the Session ID will be ``0x4A212E07``, then the resulting final Session ID will be ``0x7576E133``.


### PR DESCRIPTION
This PR adds a new folder in ``doc/IR Protocol`` to group every packet together, each packet having their own page following a standard format in the hope that this will improve the documentation readability.
As such, packet descriptions were removed from the [02 - Starting a Communication](https://github.com/mamba2410/reverse-pokewalker/blob/master/doc/IR%20Protocol/02%20-%20Starting%20a%20Communication.md) page, and replaced by links to those new pages.

The standard packet header description has also been changed to replace the 2 byte Packet ID by a 1 byte Packet ID + 1 byte Packet arg/flags.